### PR TITLE
Update from node12 to node20 to avoid GitHub Action deprecation warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
         required: false
 
 runs:
-    using: 'node16'
+    using: 'node20'
     main: 'dist/index.js'
     post: 'dist/cleanup.js'
 branding:

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
         required: false
 
 runs:
-    using: 'node12'
+    using: 'node16'
     main: 'dist/index.js'
     post: 'dist/cleanup.js'
 branding:


### PR DESCRIPTION
> The following actions uses node12 which is deprecated and will be forced to run on node16: shaunco/ssh-agent@git-repo-mapping. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: shaunco/ssh-agent@git-repo-mapping. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.